### PR TITLE
Bump minimum flatdict to 4.1, remove pkg_resources dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ssm-ps-template"
-version = "2.5.0"
+version = "2.5.1"
 description = "CLI for rendering configuration templates with SSM Parameter Store as a data source"
 authors = [
     {name = "Gavin M. Roy", email="gavinmroy@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "boto3>=1,<2",
-    "flatdict>=4,<5",
+    "flatdict>=4.1,<5",
     "jinja2>=3,<4",
     "pyyaml>=5.3.1,<7",
     "toml>=0.10,<1"


### PR DESCRIPTION
## Summary
- Bumps the minimum flatdict version from 4.0 to 4.1 to avoid the implicit `pkg_resources` dependency introduced by flatdict 4.0
- Bumps package version to 2.5.1

## Problem
flatdict 4.0 imports `pkg_resources` at module load time. `pkg_resources` (from setuptools) is not guaranteed to be available in all Python environments, causing import failures.

## Solution
flatdict 4.1+ removed the `pkg_resources` usage. Raising the minimum pin to `>=4.1` ensures builds work without setuptools installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch release 2.5.1 now available
  * Updated dependency constraint to ensure compatibility with required component versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->